### PR TITLE
Remove `transformOptions`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Kevin Kwok <kkwok@mit.edu>
 Min RK <benjaminrk@gmail.com>
 Nicolas Riesco <enquiries@nicolasriesco.net>
 Will Whitney <wfwhitney@gmail.com>
+Grant Nestor <grantnestor@gmail.com>

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -49,19 +49,19 @@ var fs = require("fs");
 var path = require("path");
 var spawn = require("child_process").spawn;
 
-function findFile(file, dir) {
-    var result = fs.readdirSync(dir).find(result => result.indexOf(file) >= 0);
-    if (result) return path.resolve(result);
-    return findFile(file, path.join(dir, ".."));
+function findFile(filename, dir) {
+    if (~fs.readdirSync(dir).indexOf(filename)) return path.resolve(dir, filename);
+    if (path.dirname(dir) === dir) return null;
+    return findFile(filename, path.dirname(dir));
 }
 
-function getBabelConfig(path) {
-  if (!path) return null;
-  try {
-    return JSON.parse(fs.readFileSync(path, "utf-8"));
-  } catch(err) {
-    return null;
-  }
+function getBabelConfig(filepath) {
+    if (!filepath) return null;
+    try {
+        return JSON.parse(fs.readFileSync(filepath, "utf-8"));
+    } catch(err) {
+        return null;
+    }
 }
 
 // Find .babelrc

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -50,11 +50,8 @@ var path = require("path");
 var spawn = require("child_process").spawn;
 
 var transform = require("babel-core").transform;
-var transformOptions = {
-    presets: ["es2015"],
-};
 var transpile = function (code) {
-    return transform(code, transformOptions).code;
+    return transform(code).code;
 };
 
 var doc = require("./mdn.js"); // Documentation for Javascript builtins

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -50,8 +50,11 @@ var path = require("path");
 var spawn = require("child_process").spawn;
 
 var transform = require("babel-core").transform;
+var transformOptions = {
+    presets: [path.resolve(path.join(__dirname, "..", "node_modules", "babel-preset-es2015"))],
+};
 var transpile = function (code) {
-    return transform(code).code;
+    return transform(code, transformOptions).code;
 };
 
 var doc = require("./mdn.js"); // Documentation for Javascript builtins

--- a/lib/nel.js
+++ b/lib/nel.js
@@ -49,9 +49,27 @@ var fs = require("fs");
 var path = require("path");
 var spawn = require("child_process").spawn;
 
+function findFile(file, dir) {
+    var result = fs.readdirSync(dir).find(result => result.indexOf(file) >= 0);
+    if (result) return path.resolve(result);
+    return findFile(file, path.join(dir, ".."));
+}
+
+function getBabelConfig(path) {
+  if (!path) return null;
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf-8"));
+  } catch(err) {
+    return null;
+  }
+}
+
+// Find .babelrc
+var babelrc = getBabelConfig(findFile('.babelrc', process.cwd()))
 var transform = require("babel-core").transform;
-var transformOptions = {
-    presets: [path.resolve(path.join(__dirname, "..", "node_modules", "babel-preset-es2015"))],
+// Use .babelrc if it exists or default es2015 preset
+var transformOptions = babelrc || {
+    presets: [require.resolve("babel-preset-es2015")],
 };
 var transpile = function (code) {
     return transform(code, transformOptions).code;


### PR DESCRIPTION
Partially fixes https://github.com/n-riesco/jp-babel/issues/2

Theoretically, if options are not passed to `babel.transform` then babel should use the `.babelrc` options. I haven't fully tested to determine if this in fact is happening. I know that module `import` is not working in the notebook within a project that has a qualified `.babelrc`...
