### PR TITLE
Use babel-preset-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo npm install -g jp-babel
 ## babelrc
 
 By default, `jp-babel` is set to use the preset
-[babel-preset-es2015](https://babeljs.io/docs/plugins/preset-es2015/). Users can
+[babel-preset-latest](https://babeljs.io/docs/plugins/preset-latest/). Users can
 customise their [.babelrc](https://babeljs.io/docs/usage/babelrc/). If they do
 so, they must ensure all the referenced plugins and presets can be required from
 within the `jp-babel` session.

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -85,7 +85,7 @@ var babelrc = getBabelrc(babelrcPath);
 
 var transform = require("babel-core").transform;
 var transformOptions = babelrc || {
-    presets: [require.resolve("babel-preset-es2015")],
+    presets: [require.resolve("babel-preset-latest")],
 };
 log("babelrcPath:", babelrcPath);
 log("transformOptions:", transformOptions);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "babel-core": "6",
         "babel-register": "6",
-        "babel-preset-es2015": "6",
+        "babel-preset-latest": "6",
         "jp-kernel": "0.0.x"
     },
     "devDependencies": {


### PR DESCRIPTION
I’m submitting this and opening it up for discussion. 

* Node 6 supports [99%](http://node.green/) of es2015. [babel-preset-latest](https://babeljs.io/docs/plugins/preset-latest/) includes es2015, es2016, es2017. I think that jp-babel should provide support for these by default but I acknowledge that there might be issues in doing so. 
* I added a “preinstall” script that should delete the `node_modules` directory before installing, so that upgrading doesn’t cause conflicts (e.g. I upgraded the babel dependencies without removing `node_modules` and got a `You gave us a visitor for the node type "ForAwaitStatement" but it's not a valid type` error). This should also address https://github.com/n-riesco/ijavascript/issues/76 regarding version mismatch of Node bindings for zmq (which require a rebuilding if the Node environment version changes).