### PR TITLE
Support typescript

### DIFF
--- a/bin/rc.js
+++ b/bin/rc.js
@@ -252,6 +252,26 @@ var FLAGS = [{
         context.args.kernel.push(
             "--session-working-dir=" + context.flag.cwd
         );
+    }
+}, {
+    prefixedFlag: "extensions=comma separated list",
+    description:
+    "set file extensions transpiled by babel " +
+    "(default = require(\"@babel/core\").DEFAULT_EXTENSIONS)",
+    parse: function(context, arg) {
+        context.args.kernel.push(
+            "--extensions=" + getValue(arg)
+        );
+    }
+}, {
+    prefixedFlag: "notebook-language=language",
+    description:
+    "transpile cells using specified language - should match filename " +
+    "extension supported by Babel (default = js)",
+    parse: function(context, arg) {
+        context.args.kernel.push(
+            "--notebook-language=" + getValue(arg)
+        );
     },
 }];
 

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -64,11 +64,29 @@ if (process.env.DEBUG) {
 
 log = global.DEBUG ? doLog : dontLog;
 
+var babelrcPath = findFile(".babelrc", process.cwd());
+var babelrc = getBabelrc(babelrcPath);
+
+var transformOptions = babelrc || {
+    presets: [
+        [require.resolve("@babel/preset-env"), {
+            loose: true,
+            targets: {node: true},
+        }],
+    ],
+};
+
+log("babelrcPath:", babelrcPath);
+log("transformOptions:", transformOptions);
 
 // Setup session initialisation
 config.startupCallback = function startupCallback() {
     var requirePath = require.resolve("@babel/register");
-    var code = "require('" + requirePath + "');";
+    var babelRegisterOptions = Object.assign(
+        {}, transformOptions, {extensions: config.extensions}
+    );
+    var code = "require('" + requirePath + "')" +
+        "(" + JSON.stringify(babelRegisterOptions) + ");";
     this.session.execute(code, {
         onSuccess: function() {
             log("startupCallback: '" + code + "' run successfuly");
@@ -79,22 +97,9 @@ config.startupCallback = function startupCallback() {
     });
 };
 
-
 // Setup babel transpiler
-var babelrcPath = findFile(".babelrc", process.cwd());
-var babelrc = getBabelrc(babelrcPath);
 
 var transform = require("@babel/core").transform;
-var transformOptions = babelrc || {
-    presets: [
-        [require.resolve("@babel/preset-env"), {
-            loose: true,
-            targets: {node: true},
-        }],
-    ],
-};
-log("babelrcPath:", babelrcPath);
-log("transformOptions:", transformOptions);
 
 function findFile(fileName, filePath) {
     var found;
@@ -126,7 +131,11 @@ function getBabelrc(filePath) {
 
 var USE_STRICT = "\"use strict\";\n\n";
 config.transpile = function transpile(code) {
-    var transpiledCode = transform(code, transformOptions).code;
+    var optionsWithFilename = Object.assign({},
+        transformOptions,
+        {filename: "filename." + config.notebookLanguage}
+    );
+    var transpiledCode = transform(code, optionsWithFilename).code;
 
     // If user didn't set .babelrc,
     // remove "use strict";\n\n from transpiled code
@@ -189,6 +198,8 @@ function parseCommandArguments() {
         cwd: process.cwd(),
         hideUndefined: true,
         protocolVersion: "5.1",
+        extensions: require("@babel/core").DEFAULT_EXTENSIONS,
+        notebookLanguage: "js"
     };
 
     var usage = (
@@ -220,6 +231,12 @@ function parseCommandArguments() {
         }],
         ["--startup-script=", function(setting) {
             config.startupScript = setting;
+        }],
+        ["--extensions=", function(extensions) {
+            config.extensions = extensions.split(",");
+        }],
+        ["--notebook-language=", function(notebookLanguage) {
+            config.notebookLanguage = notebookLanguage;
         }],
     ];
 


### PR DESCRIPTION
At the moment jp-babel doesn't work with TypeScript since babel does not by default include ".ts" in supported filename extensions (https://babeljs.io/docs/en/babel-core#default_extensions).

Additionally babel uses filename extensions to decide which presets should be enabled for a file and that was also not working.

We include to additional flags for jp-babel:
 - extensions - user can override file extensions to be transpiled by babel (this is passed down to @babel/register)
 - notebookLanguage - user can decide what language should be used to transpile notebook cells (instead of javascript which is the default)

This pull request combines all changes we did for our project to make jp-babel work.

This should also work for any other languages that babel can transpile, which are not enabled
in babel by default.

//cc @robh1